### PR TITLE
Add bytes32 UUID to an AO + refactoring

### DIFF
--- a/contracts/EIP712Verifier.sol
+++ b/contracts/EIP712Verifier.sol
@@ -6,7 +6,7 @@ import "./IEIP712Verifier.sol";
 
 /// @title EIP712 typed signatures verifier for EAS delegated attestations.
 contract EIP712Verifier is IEIP712Verifier {
-    string public constant VERSION = "0.2";
+    string public constant VERSION = "0.3";
 
     // EIP712 domain separator, making signatures from different domains incompatible.
     bytes32 public immutable DOMAIN_SEPARATOR; // solhint-disable-line var-name-mixedcase
@@ -53,7 +53,7 @@ contract EIP712Verifier is IEIP712Verifier {
     /// @dev Verifies signed attestation.
     ///
     /// @param recipient The recipient the attestation.
-    /// @param ao The ID of the AO.
+    /// @param ao The UIID of the AO.
     /// @param expirationTime The expiration time of the attestation.
     /// @param refUUID An optional related attestation's UUID.
     /// @param data The additional attestation data.
@@ -63,7 +63,7 @@ contract EIP712Verifier is IEIP712Verifier {
     /// @param s The signature data.
     function attest(
         address recipient,
-        uint256 ao,
+        bytes32 ao,
         uint256 expirationTime,
         bytes32 refUUID,
         bytes calldata data,

--- a/contracts/IAORegistry.sol
+++ b/contracts/IAORegistry.sol
@@ -1,47 +1,43 @@
 // SPDX-License-Identifier: MIT
 
 pragma solidity 0.7.6;
+pragma abicoder v2;
 
 import "./IAOVerifier.sol";
 
+// A data struct representing a record for a submitted AO (Attestation Object).
+struct AORecord {
+    bytes32 uuid;
+    uint256 index;
+    bytes schema;
+    IAOVerifier verifier;
+}
+
 /// @title The global AO registry interface.
 interface IAORegistry {
-    // A data struct representing a record for a submitted AO (Attestation Object).
-    struct AORecord {
-        uint256 id;
-        bytes schema;
-        IAOVerifier verifier;
-    }
-
     /// @dev Triggered when a new AO has been registered.
     ///
-    /// @param id The AO id.
+    /// @param uuid The AO UUID.
+    /// @param index The AO index.
     /// @param schema The AO schema.
     /// @param verifier An optional AO schema verifier.
     /// @param from The address of the account used to register the AO.
-    event Registered(uint256 indexed id, bytes schema, IAOVerifier indexed verifier, address indexed from);
+    event Registered(bytes32 indexed uuid, uint256 indexed index, bytes schema, IAOVerifier verifier, address from);
 
     /// @dev Submits and reserve a new AO.
     ///
     /// @param schema The AO data schema.
     /// @param verifier An optional AO schema verifier.
     //
-    /// @return The ID of the new AO.
-    function register(bytes calldata schema, IAOVerifier verifier) external returns (uint256);
+    /// @return The UUID of the new AO.
+    function register(bytes calldata schema, IAOVerifier verifier) external returns (bytes32);
 
-    /// @dev Returns an existing AO by ID.
+    /// @dev Returns an existing AO by UUID.
     ///
-    /// @param id The ID of the AO to retrieve.
+    /// @param uuid The UUID of the AO to retrieve.
     ///
     /// @return The AO data members.
-    function getAO(uint256 id)
-        external
-        view
-        returns (
-            uint256,
-            bytes memory,
-            IAOVerifier
-        );
+    function getAO(bytes32 uuid) external view returns (AORecord memory);
 
     /// @dev Returns the global counter for the total number of attestations.
     ///

--- a/contracts/IEAS.sol
+++ b/contracts/IEAS.sol
@@ -1,40 +1,41 @@
 // SPDX-License-Identifier: MIT
 
 pragma solidity 0.7.6;
+pragma abicoder v2;
 
 import "./IAORegistry.sol";
 import "./IEIP712Verifier.sol";
 
+// A data struct representing a single attestation.
+struct Attestation {
+    bytes32 uuid;
+    bytes32 ao;
+    address to;
+    address from;
+    uint256 time;
+    uint256 expirationTime;
+    uint256 revocationTime;
+    bytes32 refUUID;
+    bytes data;
+}
+
 /// @title EAS - Ethereum Attestation Service interface
 interface IEAS {
-    // A data struct representing a single attestation.
-    struct Attestation {
-        bytes32 uuid;
-        uint256 ao;
-        address to;
-        address from;
-        uint256 time;
-        uint256 expirationTime;
-        uint256 revocationTime;
-        bytes32 refUUID;
-        bytes data;
-    }
-
     /// @dev Triggered when an attestation has been made.
     ///
     /// @param recipient The recipient the attestation.
     /// @param attester The attesting account.
     /// @param uuid The UUID the revoked attestation.
-    /// @param ao The ID of the AO.
-    event Attested(address indexed recipient, address indexed attester, bytes32 indexed uuid, uint256 ao);
+    /// @param ao The UIID of the AO.
+    event Attested(address indexed recipient, address indexed attester, bytes32 indexed uuid, bytes32 ao);
 
     /// @dev Triggered when an attestation has been revoked.
     ///
     /// @param recipient The recipient the attestation.
     /// @param attester The attesting account.
-    /// @param ao The ID of the AO.
+    /// @param ao The UIID of the AO.
     /// @param uuid The UUID the revoked attestation.
-    event Revoked(address indexed recipient, address indexed attester, bytes32 indexed uuid, uint256 ao);
+    event Revoked(address indexed recipient, address indexed attester, bytes32 indexed uuid, bytes32 ao);
 
     /// @dev Returns the address of the AO global registry.
     ///
@@ -54,7 +55,7 @@ interface IEAS {
     /// @dev Attests to a specific AO.
     ///
     /// @param recipient The recipient the attestation.
-    /// @param ao The ID of the AO.
+    /// @param ao The UIID of the AO.
     /// @param expirationTime The expiration time of the attestation.
     /// @param refUUID An optional related attestation's UUID.
     /// @param data The additional attestation data.
@@ -62,7 +63,7 @@ interface IEAS {
     /// @return The UUID of the new attestation.
     function attest(
         address recipient,
-        uint256 ao,
+        bytes32 ao,
         uint256 expirationTime,
         bytes32 refUUID,
         bytes calldata data
@@ -71,7 +72,7 @@ interface IEAS {
     /// @dev Attests to a specific AO using a provided EIP712 signature.
     ///
     /// @param recipient The recipient the attestation.
-    /// @param ao The ID of the AO.
+    /// @param ao The UIID of the AO.
     /// @param expirationTime The expiration time of the attestation.
     /// @param refUUID An optional related attestation's UUID.
     /// @param data The additional attestation data.
@@ -83,7 +84,7 @@ interface IEAS {
     /// @return The UUID of the new attestation.
     function attestByDelegation(
         address recipient,
-        uint256 ao,
+        bytes32 ao,
         uint256 expirationTime,
         bytes32 refUUID,
         bytes calldata data,
@@ -118,20 +119,7 @@ interface IEAS {
     /// @param uuid The UUID of the attestation to retrieve.
     ///
     /// @return The attestation data members.
-    function getAttestation(bytes32 uuid)
-        external
-        view
-        returns (
-            bytes32,
-            uint256,
-            address,
-            address,
-            uint256,
-            uint256,
-            uint256,
-            bytes32,
-            bytes memory
-        );
+    function getAttestation(bytes32 uuid) external view returns (Attestation memory);
 
     /// @dev Checks whether an attestation exists.
     ///
@@ -143,7 +131,7 @@ interface IEAS {
     /// @dev Returns all received attestation UUIDs.
     ///
     /// @param recipient The recipient the attestation.
-    /// @param ao The ID of the AO.
+    /// @param ao The UUID of the AO.
     /// @param start The offset to start from.
     /// @param length The number of total members to retrieve.
     /// @param reverseOrder Whether the offset starts from the end and the data is returned in reverse.
@@ -151,7 +139,7 @@ interface IEAS {
     /// @return An array of attestation UUIDs.
     function getReceivedAttestationUUIDs(
         address recipient,
-        uint256 ao,
+        bytes32 ao,
         uint256 start,
         uint256 length,
         bool reverseOrder
@@ -160,15 +148,15 @@ interface IEAS {
     /// @dev Returns the number of received attestation UUIDs.
     ///
     /// @param recipient The recipient the attestation.
-    /// @param ao The ID of the AO.
+    /// @param ao The UIID of the AO.
     ///
     /// @return The number of attestations.
-    function getReceivedAttestationUUIDsCount(address recipient, uint256 ao) external view returns (uint256);
+    function getReceivedAttestationUUIDsCount(address recipient, bytes32 ao) external view returns (uint256);
 
     /// @dev Returns all sent attestation UUIDs.
     ///
     /// @param attester The attesting account.
-    /// @param ao The ID of the AO.
+    /// @param ao The UIID of the AO.
     /// @param start The offset to start from.
     /// @param length The number of total members to retrieve.
     /// @param reverseOrder Whether the offset starts from the end and the data is returned in reverse.
@@ -176,7 +164,7 @@ interface IEAS {
     /// @return An array of attestation UUIDs.
     function getSentAttestationUUIDs(
         address attester,
-        uint256 ao,
+        bytes32 ao,
         uint256 start,
         uint256 length,
         bool reverseOrder
@@ -185,10 +173,10 @@ interface IEAS {
     /// @dev Returns the number of sent attestation UUIDs.
     ///
     /// @param recipient The recipient the attestation.
-    /// @param ao The ID of the AO.
+    /// @param ao The UIID of the AO.
     ///
     /// @return The number of attestations.
-    function getSentAttestationUUIDsCount(address recipient, uint256 ao) external view returns (uint256);
+    function getSentAttestationUUIDsCount(address recipient, bytes32 ao) external view returns (uint256);
 
     /// @dev Returns all attestations related to a specific attestation.
     ///

--- a/contracts/IEIP712Verifier.sol
+++ b/contracts/IEIP712Verifier.sol
@@ -14,7 +14,7 @@ interface IEIP712Verifier {
     /// @dev Verifies signed attestation.
     ///
     /// @param recipient The recipient the attestation.
-    /// @param ao The ID of the AO.
+    /// @param ao The UIID of the AO.
     /// @param expirationTime The expiration time of the attestation.
     /// @param refUUID An optional related attestation's UUID.
     /// @param data The additional attestation data.
@@ -24,7 +24,7 @@ interface IEIP712Verifier {
     /// @param s The signature data.
     function attest(
         address recipient,
-        uint256 ao,
+        bytes32 ao,
         uint256 expirationTime,
         bytes32 refUUID,
         bytes calldata data,

--- a/contracts/Types.sol
+++ b/contracts/Types.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.7.6;
+
+// A representation of an empty/uninitialized UUID.
+bytes32 constant EMPTY_UUID = 0;

--- a/contracts/tests/TestEAS.sol
+++ b/contracts/tests/TestEAS.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 pragma solidity 0.7.6;
+pragma abicoder v2;
 
 import "../EAS.sol";
 
@@ -15,7 +16,7 @@ contract TestEAS is EAS {
 
     function attest(
         address recipient,
-        uint256 ao,
+        bytes32 ao,
         uint256 expirationTime,
         bytes32 refUUID,
         bytes calldata data
@@ -27,7 +28,7 @@ contract TestEAS is EAS {
 
     function attestByDelegation(
         address recipient,
-        uint256 ao,
+        bytes32 ao,
         uint256 expirationTime,
         bytes32 refUUID,
         bytes calldata data,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@ethereum-attestation-service/contracts",
-  "version": "0.2.0",
+  "name": "@ethereum-attestation-service/eas-contracts",
+  "version": "0.3.0",
   "description": "Ethereum Attestation Service",
   "repository": {
     "type": "git",

--- a/test/AORegistry.ts
+++ b/test/AORegistry.ts
@@ -8,10 +8,12 @@ import Contracts from 'components/Contracts';
 import { AORegistry } from 'typechain';
 
 const {
-  constants: { AddressZero }
+  constants: { AddressZero },
+  utils: { solidityKeccak256, formatBytes32String }
 } = ethers;
 
-const ZERO_BYTES = '0x00';
+const ZERO_BYTES = '0x';
+const ZERO_BYTES32 = '0x0000000000000000000000000000000000000000000000000000000000000000';
 
 let accounts: SignerWithAddress[];
 let sender: SignerWithAddress;
@@ -29,9 +31,11 @@ describe('AORegistry', () => {
     registry = await Contracts.AORegistry.deploy();
   });
 
+  const getUUID = (schema: string, verifier: string) => solidityKeccak256(['bytes', 'address'], [schema, verifier]);
+
   describe('construction', async () => {
     it('should report a version', async () => {
-      expect(await registry.VERSION()).to.equal('0.2');
+      expect(await registry.VERSION()).to.equal('0.3');
     });
 
     it('should initialize without any AOs', async () => {
@@ -41,21 +45,22 @@ describe('AORegistry', () => {
 
   describe('registration', async () => {
     const testRegister = async (schema: string, verifier: string | SignerWithAddress) => {
-      const prevAOCount = await registry.getAOCount();
-      const id = prevAOCount.add(BigNumber.from(1));
-
       const verifierAddress = typeof verifier === 'string' ? verifier : verifier.address;
-      const retId = await registry.callStatic.register(schema, verifierAddress);
+
+      const uuid = getUUID(schema, verifierAddress);
+      const index = (await registry.getAOCount()).add(BigNumber.from(1));
+
+      const retUUID = await registry.callStatic.register(schema, verifierAddress);
       const res = await registry.register(schema, verifierAddress);
-      expect(retId).to.equal(id);
-      await expect(res).to.emit(registry, 'Registered').withArgs(id, schema, verifierAddress, sender.address);
+      expect(retUUID).to.equal(uuid);
+      await expect(res).to.emit(registry, 'Registered').withArgs(uuid, index, schema, verifierAddress, sender.address);
+      expect(await registry.getAOCount()).to.equal(index);
 
-      expect(await registry.getAOCount()).to.equal(id);
-
-      const ao = await registry.getAO(id);
-      expect(ao[0]).to.equal(id);
-      expect(ao[1]).to.equal(schema);
-      expect(ao[2]).to.equal(verifierAddress);
+      const ao = await registry.getAO(uuid);
+      expect(ao[0]).to.equal(uuid);
+      expect(ao[1]).to.equal(index);
+      expect(ao[2]).to.equal(schema);
+      expect(ao[3]).to.equal(verifierAddress);
     };
 
     it('should allow to register an AO without a schema', async () => {
@@ -69,6 +74,11 @@ describe('AORegistry', () => {
     it('should allow to register an AO without neither a schema or a verifier', async () => {
       await testRegister(ZERO_BYTES, AddressZero);
     });
+
+    it('should not allow to register the same schema and verifier twice', async () => {
+      await testRegister('0x1234', AddressZero);
+      await expect(testRegister('0x1234', AddressZero)).to.be.revertedWith('ERR_ALREADY_EXISTS');
+    });
   });
 
   describe('AO querying', async () => {
@@ -78,18 +88,20 @@ describe('AORegistry', () => {
 
       await registry.register(schema, verifier.address);
 
-      const id = BigNumber.from(1);
-      const ao = await registry.getAO(id);
-      expect(ao[0]).to.equal(id);
-      expect(ao[1]).to.equal(schema);
-      expect(ao[2]).to.equal(verifier.address);
+      const uuid = getUUID(schema, verifier.address);
+      const ao = await registry.getAO(uuid);
+      expect(ao[0]).to.equal(uuid);
+      expect(ao[1]).to.equal(BigNumber.from(1));
+      expect(ao[2]).to.equal(schema);
+      expect(ao[3]).to.equal(verifier.address);
     });
 
     it('should return an empty AO given non-existing id', async () => {
-      const ao = await registry.getAO(BigNumber.from(10000));
-      expect(ao[0]).to.equal(BigNumber.from(0));
-      expect(ao[1]).to.equal('0x');
-      expect(ao[2]).to.equal(AddressZero);
+      const ao = await registry.getAO(formatBytes32String('BAD'));
+      expect(ao[0]).to.equal(ZERO_BYTES32);
+      expect(ao[1]).to.equal(BigNumber.from(0));
+      expect(ao[2]).to.equal(ZERO_BYTES);
+      expect(ao[3]).to.equal(AddressZero);
     });
   });
 });

--- a/test/EIP712Verifier.ts
+++ b/test/EIP712Verifier.ts
@@ -20,6 +20,10 @@ describe('EIP712Verifier', () => {
     verifier = await Contracts.EIP712Verifier.deploy();
   });
 
+  it('should report a version', async () => {
+    expect(await verifier.VERSION()).to.equal('0.3');
+  });
+
   it('should return the correct domain separator', async () => {
     const delegation = new Delegation({
       address: verifier.address,

--- a/test/helpers/EIP712Utils.ts
+++ b/test/helpers/EIP712Utils.ts
@@ -15,14 +15,14 @@ export class EIP712Utils {
 
     this.delegation = new Delegation({
       address: contractAddress,
-      version: '0.2',
+      version: '0.3',
       chainId: HARDHAT_CHAIN_ID
     });
   }
 
   async getAttestationRequest(
     recipient: string | SignerWithAddress,
-    ao: BigNumber,
+    ao: string,
     expirationTime: BigNumber,
     refUUID: string,
     data: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,8 +40,8 @@
   integrity sha512-bvaTH34PMCbv6anRa9I/0zjLJgY4EuznbEMgbV77JBCQ9KNC46rzi0avuxpOfu+xDjPEtSFGqVEOr5GlUSGudA==
 
 "@ethereum-attestation-service/eas-sdk@ethereum-attestation-service/eas-sdk.git":
-  version "0.9.0"
-  resolved "git+ssh://git@github.com/ethereum-attestation-service/eas-sdk.git#3fe5e447a64d0dca4bbd9d99dccf9f9a03821dad"
+  version "0.10.0"
+  resolved "git+ssh://git@github.com/ethereum-attestation-service/eas-sdk.git#6066e2f1fce34d3a425908bc61b8c411cee7bf9f"
   dependencies:
     ethers "^5.4.0"
 


### PR DESCRIPTION
- Add `bytes32` UUID to an `AO` and rename its previous `id` to `index`
- Work directly with structs using ABIEncoder V2
- Additional refactoring