### PR TITLE
Adding ERC1271 to signature validation

### DIFF
--- a/contracts/eip712/EIP712Verifier.sol
+++ b/contracts/eip712/EIP712Verifier.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.19;
 
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 
 // prettier-ignore
 import {


### PR DESCRIPTION
EAS currently only supports attestations and revocations made by EOA wallets. 

I suggest adding ERC1271 support to allow smart accounts to use EAS as well.