### PR TITLE
feat: ERC1271 standard support

### DIFF
--- a/contracts/EAS.sol
+++ b/contracts/EAS.sol
@@ -25,9 +25,13 @@ import {
     DelegatedAttestationRequest,
     DelegatedRevocationRequest,
     IEAS,
+    ERC1271DelegatedAttestationRequest,
+    ERC1271DelegatedRevocationRequest,
     MultiAttestationRequest,
     MultiDelegatedAttestationRequest,
+    MultiERC1271DelegatedAttestationRequest,
     MultiDelegatedRevocationRequest,
+    MultiERC1271DelegatedRevocationRequest,
     MultiRevocationRequest,
     RevocationRequest,
     RevocationRequestData
@@ -104,6 +108,18 @@ contract EAS is IEAS, Semver, EIP1271Verifier {
         DelegatedAttestationRequest calldata delegatedRequest
     ) external payable returns (bytes32) {
         _verifyAttest(delegatedRequest);
+
+        AttestationRequestData[] memory data = new AttestationRequestData[](1);
+        data[0] = delegatedRequest.data;
+
+        return _attest(delegatedRequest.schema, data, delegatedRequest.attester, msg.value, true).uids[0];
+    }
+
+    /// @inheritdoc IEAS
+    function attestByERC1271Delegation(
+        ERC1271DelegatedAttestationRequest calldata delegatedRequest
+    ) external payable returns (bytes32) {
+        _verifyERC1271Attest(delegatedRequest);
 
         AttestationRequestData[] memory data = new AttestationRequestData[](1);
         data[0] = delegatedRequest.data;
@@ -235,6 +251,76 @@ contract EAS is IEAS, Semver, EIP1271Verifier {
     }
 
     /// @inheritdoc IEAS
+    function multiAttestByERC1271Delegation(
+        MultiERC1271DelegatedAttestationRequest[] calldata multiDelegatedRequests
+    ) external payable returns (bytes32[] memory) {
+        // Since a multi-attest call is going to make multiple attestations for multiple schemas, we'd need to collect
+        // all the returned UIDs into a single list.
+        uint256 length = multiDelegatedRequests.length;
+        bytes32[][] memory totalUIDs = new bytes32[][](length);
+        uint256 totalUIDCount = 0;
+
+        // We are keeping track of the total available ETH amount that can be sent to resolvers and will keep deducting
+        // from it to verify that there isn't any attempt to send too much ETH to resolvers. Please note that unless
+        // some ETH was stuck in the contract by accident (which shouldn't happen in normal conditions), it won't be
+        // possible to send too much ETH anyway.
+        uint256 availableValue = msg.value;
+
+        for (uint256 i = 0; i < length; ++i) {
+            // The last batch is handled slightly differently: if the total available ETH wasn't spent in full and there
+            // is a remainder - it will be refunded back to the attester (something that we can only verify during the
+            // last and final batch).
+            bool last;
+            unchecked {
+                last = i == length - 1;
+            }
+
+            MultiERC1271DelegatedAttestationRequest calldata multiDelegatedRequest = multiDelegatedRequests[i];
+            AttestationRequestData[] calldata data = multiDelegatedRequest.data;
+
+            // Ensure that no inputs are missing.
+            uint256 dataLength = data.length;
+            if (dataLength == 0 || dataLength != multiDelegatedRequest.signatures.length) {
+                revert InvalidLength();
+            }
+
+            // Verify signatures. Please note that the signatures are assumed to be signed with increasing nonces.
+            for (uint256 j = 0; j < dataLength; ++j) {
+                _verifyERC1271Attest(
+                    ERC1271DelegatedAttestationRequest({
+                        schema: multiDelegatedRequest.schema,
+                        data: data[j],
+                        signature: multiDelegatedRequest.signatures[j],
+                        attester: multiDelegatedRequest.attester,
+                        deadline: multiDelegatedRequest.deadline
+                    })
+                );
+            }
+
+            // Process the current batch of attestations.
+            AttestationsResult memory res = _attest(
+                multiDelegatedRequest.schema,
+                data,
+                multiDelegatedRequest.attester,
+                availableValue,
+                last
+            );
+
+            // Ensure to deduct the ETH that was forwarded to the resolver during the processing of this batch.
+            availableValue -= res.usedValue;
+
+            // Collect UIDs (and merge them later).
+            totalUIDs[i] = res.uids;
+            unchecked {
+                totalUIDCount += res.uids.length;
+            }
+        }
+
+        // Merge all the collected UIDs and return them as a flatten array.
+        return _mergeUIDs(totalUIDs, totalUIDCount);
+    }
+
+    /// @inheritdoc IEAS
     function revoke(RevocationRequest calldata request) external payable {
         RevocationRequestData[] memory data = new RevocationRequestData[](1);
         data[0] = request.data;
@@ -245,6 +331,16 @@ contract EAS is IEAS, Semver, EIP1271Verifier {
     /// @inheritdoc IEAS
     function revokeByDelegation(DelegatedRevocationRequest calldata delegatedRequest) external payable {
         _verifyRevoke(delegatedRequest);
+
+        RevocationRequestData[] memory data = new RevocationRequestData[](1);
+        data[0] = delegatedRequest.data;
+
+        _revoke(delegatedRequest.schema, data, delegatedRequest.revoker, msg.value, true);
+    }
+
+    /// @inheritdoc IEAS
+    function revokeByERC1271Delegation(ERC1271DelegatedRevocationRequest calldata delegatedRequest) external payable {
+        _verifyERC1271Revoke(delegatedRequest);
 
         RevocationRequestData[] memory data = new RevocationRequestData[](1);
         data[0] = delegatedRequest.data;
@@ -310,6 +406,59 @@ contract EAS is IEAS, Semver, EIP1271Verifier {
             for (uint256 j = 0; j < dataLength; ++j) {
                 _verifyRevoke(
                     DelegatedRevocationRequest({
+                        schema: multiDelegatedRequest.schema,
+                        data: data[j],
+                        signature: multiDelegatedRequest.signatures[j],
+                        revoker: multiDelegatedRequest.revoker,
+                        deadline: multiDelegatedRequest.deadline
+                    })
+                );
+            }
+
+            // Ensure to deduct the ETH that was forwarded to the resolver during the processing of this batch.
+            availableValue -= _revoke(
+                multiDelegatedRequest.schema,
+                data,
+                multiDelegatedRequest.revoker,
+                availableValue,
+                last
+            );
+        }
+    }
+
+    /// @inheritdoc IEAS
+    function multiRevokeByERC1271Delegation(
+        MultiERC1271DelegatedRevocationRequest[] calldata multiDelegatedRequests
+    ) external payable {
+        // We are keeping track of the total available ETH amount that can be sent to resolvers and will keep deducting
+        // from it to verify that there isn't any attempt to send too much ETH to resolvers. Please note that unless
+        // some ETH was stuck in the contract by accident (which shouldn't happen in normal conditions), it won't be
+        // possible to send too much ETH anyway.
+        uint256 availableValue = msg.value;
+
+        uint256 length = multiDelegatedRequests.length;
+        for (uint256 i = 0; i < length; ++i) {
+            // The last batch is handled slightly differently: if the total available ETH wasn't spent in full and there
+            // is a remainder - it will be refunded back to the attester (something that we can only verify during the
+            // last and final batch).
+            bool last;
+            unchecked {
+                last = i == length - 1;
+            }
+
+            MultiERC1271DelegatedRevocationRequest memory multiDelegatedRequest = multiDelegatedRequests[i];
+            RevocationRequestData[] memory data = multiDelegatedRequest.data;
+
+            // Ensure that no inputs are missing.
+            uint256 dataLength = data.length;
+            if (dataLength == 0 || dataLength != multiDelegatedRequest.signatures.length) {
+                revert InvalidLength();
+            }
+
+            // Verify signatures. Please note that the signatures are assumed to be signed with increasing nonces.
+            for (uint256 j = 0; j < dataLength; ++j) {
+                _verifyERC1271Revoke(
+                    ERC1271DelegatedRevocationRequest({
                         schema: multiDelegatedRequest.schema,
                         data: data[j],
                         signature: multiDelegatedRequest.signatures[j],

--- a/contracts/IEAS.sol
+++ b/contracts/IEAS.sol
@@ -31,6 +31,15 @@ struct DelegatedAttestationRequest {
     uint64 deadline; // The deadline of the signature/request.
 }
 
+/// @notice A struct representing the full arguments of the ERC1271 delegated attestation request.
+struct ERC1271DelegatedAttestationRequest {
+    bytes32 schema; // The unique identifier of the schema.
+    AttestationRequestData data; // The arguments of the attestation request.
+    bytes signature; // The ERC1271 signature data.
+    address attester; // The attesting account.
+    uint64 deadline; // The deadline of the signature/request.
+}
+
 /// @notice A struct representing the full arguments of the multi attestation request.
 struct MultiAttestationRequest {
     bytes32 schema; // The unique identifier of the schema.
@@ -42,6 +51,15 @@ struct MultiDelegatedAttestationRequest {
     bytes32 schema; // The unique identifier of the schema.
     AttestationRequestData[] data; // The arguments of the attestation requests.
     Signature[] signatures; // The ECDSA signatures data. Please note that the signatures are assumed to be signed with increasing nonces.
+    address attester; // The attesting account.
+    uint64 deadline; // The deadline of the signature/request.
+}
+
+/// @notice A struct representing the full arguments of the ERC1271 delegated multi attestation request.
+struct MultiERC1271DelegatedAttestationRequest {
+    bytes32 schema; // The unique identifier of the schema.
+    AttestationRequestData[] data; // The arguments of the attestation requests.
+    bytes[] signatures; // The ERC1271 signatures data. Please note that the signatures are assumed to be signed with increasing nonces.
     address attester; // The attesting account.
     uint64 deadline; // The deadline of the signature/request.
 }
@@ -67,6 +85,15 @@ struct DelegatedRevocationRequest {
     uint64 deadline; // The deadline of the signature/request.
 }
 
+/// @notice A struct representing the arguments of the ERC1271 delegated revocation request.
+struct ERC1271DelegatedRevocationRequest {
+    bytes32 schema; // The unique identifier of the schema.
+    RevocationRequestData data; // The arguments of the revocation request.
+    bytes signature; // The ERC1271 signature data.
+    address revoker; // The revoking account.
+    uint64 deadline; // The deadline of the signature/request.
+}
+
 /// @notice A struct representing the full arguments of the multi revocation request.
 struct MultiRevocationRequest {
     bytes32 schema; // The unique identifier of the schema.
@@ -78,6 +105,15 @@ struct MultiDelegatedRevocationRequest {
     bytes32 schema; // The unique identifier of the schema.
     RevocationRequestData[] data; // The arguments of the revocation requests.
     Signature[] signatures; // The ECDSA signatures data. Please note that the signatures are assumed to be signed with increasing nonces.
+    address revoker; // The revoking account.
+    uint64 deadline; // The deadline of the signature/request.
+}
+
+/// @notice A struct representing the full arguments of the ERC1271 delegated multi revocation request.
+struct MultiERC1271DelegatedRevocationRequest {
+    bytes32 schema; // The unique identifier of the schema.
+    RevocationRequestData[] data; // The arguments of the revocation requests.
+    bytes[] signatures; // The ERC1271 signatures data. Please note that the signatures are assumed to be signed with increasing nonces.
     address revoker; // The revoking account.
     uint64 deadline; // The deadline of the signature/request.
 }
@@ -159,6 +195,13 @@ interface IEAS is ISemver {
         DelegatedAttestationRequest calldata delegatedRequest
     ) external payable returns (bytes32);
 
+    /// @notice Attests to a specific schema via the provided ERC1271 signature.
+    /// @param delegatedRequest The arguments of the ERC1271 delegated attestation request.
+    /// @return The UID of the new attestation.
+    function attestByERC1271Delegation(
+        ERC1271DelegatedAttestationRequest calldata delegatedRequest
+    ) external payable returns (bytes32);
+
     /// @notice Attests to multiple schemas.
     /// @param multiRequests The arguments of the multi attestation requests. The requests should be grouped by distinct
     ///     schema ids to benefit from the best batching optimization.
@@ -238,6 +281,14 @@ interface IEAS is ISemver {
         MultiDelegatedAttestationRequest[] calldata multiDelegatedRequests
     ) external payable returns (bytes32[] memory);
 
+    /// @notice Attests to multiple schemas using via provided ERC1271 signatures.
+    /// @param multiDelegatedRequests The arguments of the ERC1271 delegated multi attestation requests. The requests should be
+    ///     grouped by distinct schema ids to benefit from the best batching optimization.
+    /// @return The UIDs of the new attestations.
+    function multiAttestByERC1271Delegation(
+        MultiERC1271DelegatedAttestationRequest[] calldata multiDelegatedRequests
+    ) external payable returns (bytes32[] memory);
+
     /// @notice Revokes an existing attestation to a specific schema.
     /// @param request The arguments of the revocation request.
     ///
@@ -270,6 +321,10 @@ interface IEAS is ISemver {
     ///         deadline: 1673891048
     ///     })
     function revokeByDelegation(DelegatedRevocationRequest calldata delegatedRequest) external payable;
+
+    /// @notice Revokes an existing attestation to a specific schema via the provided ERC1271 signature.
+    /// @param delegatedRequest The arguments of the ERC1271 delegated revocation request.
+    function revokeByERC1271Delegation(ERC1271DelegatedRevocationRequest calldata delegatedRequest) external payable;
 
     /// @notice Revokes existing attestations to multiple schemas.
     /// @param multiRequests The arguments of the multi revocation requests. The requests should be grouped by distinct
@@ -326,6 +381,13 @@ interface IEAS is ISemver {
     ///     }])
     function multiRevokeByDelegation(
         MultiDelegatedRevocationRequest[] calldata multiDelegatedRequests
+    ) external payable;
+
+    /// @notice Revokes existing attestations to multiple schemas via provided ERC1271 signatures.
+    /// @param multiDelegatedRequests The arguments of the ERC1271 delegated multi revocation requests. The requests
+    ///     should be grouped by distinct schema ids to benefit from the best batching optimization.
+    function multiRevokeByERC1271Delegation(
+        MultiERC1271DelegatedRevocationRequest[] calldata multiDelegatedRequests
     ) external payable;
 
     /// @notice Timestamps the specified bytes32 data.

--- a/contracts/eip1271/EIP1271Verifier.sol
+++ b/contracts/eip1271/EIP1271Verifier.sol
@@ -12,6 +12,8 @@ import {
     AttestationRequestData,
     DelegatedAttestationRequest,
     DelegatedRevocationRequest,
+    ERC1271DelegatedAttestationRequest,
+    ERC1271DelegatedRevocationRequest,
     RevocationRequestData
 } from "../IEAS.sol";
 
@@ -129,6 +131,38 @@ abstract contract EIP1271Verifier is EIP712 {
         }
     }
 
+    /// @dev Verifies ERC1271 delegated attestation request.
+    /// @param request The arguments of the ERC1271 delegated attestation request.
+    function _verifyERC1271Attest(ERC1271DelegatedAttestationRequest memory request) internal {
+        if (request.deadline != NO_EXPIRATION_TIME && request.deadline < _time()) {
+            revert DeadlineExpired();
+        }
+
+        AttestationRequestData memory data = request.data;
+        bytes memory signature = request.signature;
+
+        bytes32 hash = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    ATTEST_TYPEHASH,
+                    request.attester,
+                    request.schema,
+                    data.recipient,
+                    data.expirationTime,
+                    data.revocable,
+                    data.refUID,
+                    keccak256(data.data),
+                    data.value,
+                    _nonces[request.attester]++,
+                    request.deadline
+                )
+            )
+        );
+        if (!SignatureChecker.isValidERC1271SignatureNow(request.attester, hash, signature)) {
+            revert InvalidSignature();
+        }
+    }
+
     /// @dev Verifies delegated revocation request.
     /// @param request The arguments of the delegated revocation request.
     function _verifyRevoke(DelegatedRevocationRequest memory request) internal {
@@ -159,6 +193,34 @@ abstract contract EIP1271Verifier is EIP712 {
                 abi.encodePacked(signature.r, signature.s, signature.v)
             )
         ) {
+            revert InvalidSignature();
+        }
+    }
+
+    /// @dev Verifies ERC1271 delegated revocation request.
+    /// @param request The arguments of the ERC1271 delegated revocation request.
+    function _verifyERC1271Revoke(ERC1271DelegatedRevocationRequest memory request) internal {
+        if (request.deadline != NO_EXPIRATION_TIME && request.deadline < _time()) {
+            revert DeadlineExpired();
+        }
+
+        RevocationRequestData memory data = request.data;
+        bytes memory signature = request.signature;
+
+        bytes32 hash = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    REVOKE_TYPEHASH,
+                    request.revoker,
+                    request.schema,
+                    data.uid,
+                    data.value,
+                    _nonces[request.revoker]++,
+                    request.deadline
+                )
+            )
+        );
+        if (!SignatureChecker.isValidERC1271SignatureNow(request.revoker, hash, signature)) {
             revert InvalidSignature();
         }
     }

--- a/contracts/tests/eip1271/TestEIP1271Verifier.sol
+++ b/contracts/tests/eip1271/TestEIP1271Verifier.sol
@@ -3,7 +3,12 @@
 pragma solidity 0.8.28;
 
 import { EIP1271Verifier } from "../../eip1271/EIP1271Verifier.sol";
-import { DelegatedAttestationRequest, DelegatedRevocationRequest } from "../../IEAS.sol";
+import {
+    DelegatedAttestationRequest,
+    DelegatedRevocationRequest,
+    ERC1271DelegatedAttestationRequest,
+    ERC1271DelegatedRevocationRequest
+} from "../../IEAS.sol";
 import { Semver } from "../../Semver.sol";
 
 contract TestEIP1271Verifier is Semver, EIP1271Verifier {
@@ -15,5 +20,13 @@ contract TestEIP1271Verifier is Semver, EIP1271Verifier {
 
     function verifyRevoke(DelegatedRevocationRequest memory request) external {
         _verifyRevoke(request);
+    }
+
+    function verifyERC1271Attest(ERC1271DelegatedAttestationRequest memory request) external {
+        _verifyERC1271Attest(request);
+    }
+
+    function verifyERC1271Revoke(ERC1271DelegatedRevocationRequest memory request) external {
+        _verifyERC1271Revoke(request);
     }
 }

--- a/test/EAS.ts
+++ b/test/EAS.ts
@@ -1,6 +1,6 @@
 import { encodeBytes32String, Signer } from 'ethers';
 import { ethers } from 'hardhat';
-import Contracts from '../components/Contracts';
+import Contracts, { TestEIP1271Signer } from '../components/Contracts';
 import { SchemaRegistry, TestEAS, TestEIP712Proxy } from '../typechain-types';
 import { NO_EXPIRATION, ZERO_ADDRESS, ZERO_BYTES32 } from '../utils/Constants';
 import { getSchemaUID, getUIDFromAttestTx } from '../utils/EAS';
@@ -43,6 +43,8 @@ describe('EAS', () => {
     [recipient, recipient2] = accounts;
   });
 
+  let erc1271Signer: TestEIP1271Signer;
+
   beforeEach(async () => {
     sender = await createWallet();
     sender2 = await createWallet();
@@ -54,6 +56,8 @@ describe('EAS', () => {
 
     eip712Utils = await EIP712Utils.fromVerifier(eas);
     eip712ProxyUtils = await EIP712ProxyUtils.fromProxy(proxy);
+
+    erc1271Signer = await Contracts.TestEIP1271Signer.deploy();
 
     const now = await latest();
     expect(await eas.getTime()).to.equal(now);
@@ -82,7 +86,12 @@ describe('EAS', () => {
       expirationTime = (await eas.getTime()) + duration.days(30n);
     });
 
-    for (const signatureType of [SignatureType.Direct, SignatureType.Delegated, SignatureType.DelegatedProxy]) {
+    for (const signatureType of [
+      SignatureType.Direct,
+      SignatureType.Delegated,
+      SignatureType.DelegatedProxy,
+      SignatureType.ERC1271Delegated
+    ]) {
       context(`via ${signatureType} attestation`, () => {
         it('should revert when attesting to an unregistered schema', async () => {
           await expectFailedAttestation(
@@ -194,7 +203,7 @@ describe('EAS', () => {
           it('should revert when multi attesting to multiple unregistered schemas', async () => {
             // Only one of the requests is to an unregistered schema
             await expectFailedMultiAttestations(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               [
                 {
                   schema: schema1Id,
@@ -256,7 +265,7 @@ describe('EAS', () => {
 
             // The first request is invalid
             await expectFailedMultiAttestations(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               [
                 {
                   schema: schema1Id,
@@ -290,7 +299,7 @@ describe('EAS', () => {
 
             // The second request is invalid
             await expectFailedMultiAttestations(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               [
                 {
                   schema: schema1Id,
@@ -325,14 +334,14 @@ describe('EAS', () => {
 
           it('should allow attesting to an empty recipient', async () => {
             await expectAttestation(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               schema1Id,
               { recipient: ZERO_ADDRESS, expirationTime, data: '0x00' },
               { signatureType, from: sender }
             );
 
             await expectMultiAttestations(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               [
                 {
                   schema: schema1Id,
@@ -355,14 +364,14 @@ describe('EAS', () => {
 
           it('should allow self attestations', async () => {
             await expectAttestation(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               schema2Id,
               { recipient: await sender.getAddress(), expirationTime, data: encodeBytes32String('0') },
               { signatureType, from: sender }
             );
 
             await expectMultiAttestations(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               [
                 {
                   schema: schema1Id,
@@ -1065,6 +1074,106 @@ describe('EAS', () => {
         ])
       ).to.be.revertedWithCustomError(eas, 'InvalidLength');
     });
+
+    it('should revert when multi ERC1271 delegation attesting with inconsistent input lengths', async () => {
+      const schema = 'bool count, bytes32 id';
+      const schemaId = getSchemaUID(schema, ZERO_ADDRESS, true);
+      await registry.register(schema, ZERO_ADDRESS, true);
+
+      const erc1271Address = await erc1271Signer.getAddress();
+      const dummySignature = '0x' + '1'.repeat(130); // 65 bytes signature
+
+      await expect(
+        eas.multiAttestByERC1271Delegation([
+          {
+            schema: schemaId,
+            data: [
+              {
+                recipient: await recipient.getAddress(),
+                expirationTime,
+                revocable: true,
+                refUID: ZERO_BYTES32,
+                data: ZERO_BYTES32,
+                value: 0
+              },
+              {
+                recipient: await recipient.getAddress(),
+                expirationTime,
+                revocable: true,
+                refUID: ZERO_BYTES32,
+                data: ZERO_BYTES32,
+                value: 0
+              }
+            ],
+            signatures: [dummySignature],
+            attester: erc1271Address,
+            deadline: NO_EXPIRATION
+          }
+        ])
+      ).to.be.revertedWithCustomError(eas, 'InvalidLength');
+
+      await expect(
+        eas.multiAttestByERC1271Delegation([
+          {
+            schema: schemaId,
+            data: [],
+            signatures: [dummySignature],
+            attester: erc1271Address,
+            deadline: NO_EXPIRATION
+          }
+        ])
+      ).to.be.revertedWithCustomError(eas, 'InvalidLength');
+
+      await expect(
+        eas.multiAttestByERC1271Delegation([
+          {
+            schema: schemaId,
+            data: [
+              {
+                recipient: await recipient.getAddress(),
+                expirationTime,
+                revocable: true,
+                refUID: ZERO_BYTES32,
+                data: ZERO_BYTES32,
+                value: 0
+              }
+            ],
+            signatures: [dummySignature, dummySignature],
+            attester: erc1271Address,
+            deadline: NO_EXPIRATION
+          }
+        ])
+      ).to.be.revertedWithCustomError(eas, 'InvalidLength');
+
+      await expect(
+        eas.multiAttestByERC1271Delegation([
+          {
+            schema: schemaId,
+            data: [
+              {
+                recipient: await recipient.getAddress(),
+                expirationTime,
+                revocable: true,
+                refUID: ZERO_BYTES32,
+                data: ZERO_BYTES32,
+                value: 0
+              },
+              {
+                recipient: await recipient.getAddress(),
+                expirationTime,
+                revocable: true,
+                refUID: ZERO_BYTES32,
+                data: ZERO_BYTES32,
+                value: 0
+              }
+            ],
+            signatures: [],
+            attester: erc1271Address,
+            deadline: NO_EXPIRATION
+          }
+        ])
+      ).to.be.revertedWithCustomError(eas, 'InvalidLength');
+    });
   });
 
   describe('revocation', () => {
@@ -1080,14 +1189,19 @@ describe('EAS', () => {
       expirationTime = (await eas.getTime()) + duration.days(30n);
     });
 
-    for (const signatureType of [SignatureType.Direct, SignatureType.Delegated, SignatureType.DelegatedProxy]) {
+    for (const signatureType of [
+      SignatureType.Direct,
+      SignatureType.Delegated,
+      SignatureType.DelegatedProxy,
+      SignatureType.ERC1271Delegated
+    ]) {
       context(`via ${signatureType} revocation`, () => {
         let uid: string;
         let uids: string[] = [];
 
         beforeEach(async () => {
           ({ uid } = await expectAttestation(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             schemaId,
             { recipient: ZERO_ADDRESS, expirationTime, data: encodeBytes32String('0') },
             { signatureType, from: sender }
@@ -1097,7 +1211,7 @@ describe('EAS', () => {
 
           for (let i = 0; i < 2; i++) {
             const { uid: newUID } = await expectAttestation(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               schemaId,
               { recipient: ZERO_ADDRESS, expirationTime, data: encodeBytes32String((i + 1).toString()) },
               { signatureType, from: sender }
@@ -1109,7 +1223,7 @@ describe('EAS', () => {
 
         it('should revert when revoking a non-existing attestation', async () => {
           await expectFailedRevocation(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             schemaId,
             { uid: encodeBytes32String('BAD') },
             { signatureType, from: sender },
@@ -1117,14 +1231,14 @@ describe('EAS', () => {
           );
 
           await expectFailedMultiRevocations(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             [{ schema: schemaId, requests: [{ uid: encodeBytes32String('BAD') }, { uid }] }],
             { signatureType, from: sender },
             'NotFound'
           );
 
           await expectFailedMultiRevocations(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             [{ schema: schemaId, requests: [{ uid }, { uid: encodeBytes32String('BAD') }] }],
             { signatureType, from: sender },
             'NotFound'
@@ -1133,7 +1247,7 @@ describe('EAS', () => {
 
         it("should revert when revoking a someone's else attestation", async () => {
           await expectFailedRevocation(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             schemaId,
             { uid },
             { signatureType, from: sender2 },
@@ -1141,14 +1255,14 @@ describe('EAS', () => {
           );
 
           await expectFailedMultiRevocations(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             [{ schema: schemaId, requests: [{ uid }, { uid: uids[0] }] }],
             { signatureType, from: sender2 },
             'AccessDenied'
           );
 
           await expectFailedMultiRevocations(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             [{ schema: schemaId, requests: [{ uid: uids[1] }, { uid }] }],
             { signatureType, from: sender2 },
             'AccessDenied'
@@ -1157,14 +1271,14 @@ describe('EAS', () => {
 
         it('should allow to revoke existing attestations', async () => {
           await expectRevocation(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             schemaId,
             { uid },
             { signatureType, from: sender }
           );
 
           await expectMultiRevocations(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             [
               {
                 schema: schemaId,
@@ -1177,14 +1291,14 @@ describe('EAS', () => {
 
         it('should revert when revoking an already revoked attestation', async () => {
           await expectRevocation(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             schemaId,
             { uid },
             { signatureType, from: sender }
           );
 
           await expectFailedRevocation(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             schemaId,
             { uid },
             { signatureType, from: sender, deadline: (await latest()) + duration.days(1n) },
@@ -1192,14 +1306,14 @@ describe('EAS', () => {
           );
 
           await expectFailedMultiRevocations(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             [{ schema: schemaId, requests: [{ uid }, { uid: uids[0] }] }],
             { signatureType, from: sender, deadline: (await latest()) + duration.days(1n) },
             'AlreadyRevoked'
           );
 
           await expectFailedMultiRevocations(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             [{ schema: schemaId, requests: [{ uid: uids[1] }, { uid }] }],
             { signatureType, from: sender, deadline: (await latest()) + duration.days(1n) },
             'AlreadyRevoked'
@@ -1212,7 +1326,7 @@ describe('EAS', () => {
           await registry.register(schema2, ZERO_ADDRESS, true);
 
           await expectFailedRevocation(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             schema2Id,
             { uid },
             { signatureType, from: sender },
@@ -1220,7 +1334,7 @@ describe('EAS', () => {
           );
 
           await expectFailedMultiRevocations(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             [
               { schema: schema2Id, requests: [{ uid }] },
               { schema: schemaId, requests: [{ uid: uids[0] }] }
@@ -1230,7 +1344,7 @@ describe('EAS', () => {
           );
 
           await expectFailedMultiRevocations(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             [
               { schema: schemaId, requests: [{ uid }] },
               { schema: schema2Id, requests: [{ uid: uids[0] }] }
@@ -1242,7 +1356,7 @@ describe('EAS', () => {
 
         it('should revert when attempting to revoke attestations while specifying an empty schema', async () => {
           await expectFailedRevocation(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             ZERO_BYTES32,
             { uid },
             { signatureType, from: sender },
@@ -1250,7 +1364,7 @@ describe('EAS', () => {
           );
 
           await expectFailedMultiRevocations(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             [
               { schema: ZERO_BYTES32, requests: [{ uid }] },
               { schema: schemaId, requests: [{ uid: uids[0] }] }
@@ -1260,7 +1374,7 @@ describe('EAS', () => {
           );
 
           await expectFailedMultiRevocations(
-            { eas, eip712Utils, eip712ProxyUtils },
+            { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
             [
               { schema: schemaId, requests: [{ uid }] },
               { schema: ZERO_BYTES32, requests: [{ uid: uids[0] }] }
@@ -1273,7 +1387,7 @@ describe('EAS', () => {
         context('with irrevocable attestations', () => {
           beforeEach(async () => {
             ({ uid } = await expectAttestation(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               schemaId,
               { recipient: ZERO_ADDRESS, expirationTime, revocable: false, data: encodeBytes32String('0') },
               { signatureType, from: sender }
@@ -1283,7 +1397,7 @@ describe('EAS', () => {
 
             for (let i = 0; i < 2; i++) {
               const { uid: newUID } = await expectAttestation(
-                { eas, eip712Utils, eip712ProxyUtils },
+                { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
                 schemaId,
                 {
                   recipient: ZERO_ADDRESS,
@@ -1300,7 +1414,7 @@ describe('EAS', () => {
 
           it('should revert when revoking', async () => {
             await expectFailedRevocation(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               schemaId,
               { uid },
               { signatureType, from: sender },
@@ -1308,14 +1422,14 @@ describe('EAS', () => {
             );
 
             await expectFailedMultiRevocations(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               [{ schema: schemaId, requests: [{ uid }, { uid: uids[0] }] }],
               { signatureType, from: sender },
               'Irrevocable'
             );
 
             await expectFailedMultiRevocations(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               [{ schema: schemaId, requests: [{ uid: uids[1] }, { uid }] }],
               { signatureType, from: sender },
               'Irrevocable'
@@ -1331,7 +1445,7 @@ describe('EAS', () => {
             await registry.register(schema2, ZERO_ADDRESS, false);
 
             ({ uid } = await expectAttestation(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               schema2Id,
               { recipient: ZERO_ADDRESS, expirationTime, revocable: false, data: encodeBytes32String('0') },
               { signatureType, from: sender }
@@ -1341,7 +1455,7 @@ describe('EAS', () => {
 
             for (let i = 0; i < 2; i++) {
               const { uid: newUID } = await expectAttestation(
-                { eas, eip712Utils, eip712ProxyUtils },
+                { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
                 schema2Id,
                 {
                   recipient: ZERO_ADDRESS,
@@ -1358,7 +1472,7 @@ describe('EAS', () => {
 
           it('should revert when revoking', async () => {
             await expectFailedRevocation(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               schema2Id,
               { uid },
               { signatureType, from: sender },
@@ -1366,14 +1480,14 @@ describe('EAS', () => {
             );
 
             await expectFailedMultiRevocations(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               [{ schema: schema2Id, requests: [{ uid }, { uid: uids[0] }] }],
               { signatureType, from: sender },
               'Irrevocable'
             );
 
             await expectFailedMultiRevocations(
-              { eas, eip712Utils, eip712ProxyUtils },
+              { eas, eip712Utils, eip712ProxyUtils, erc1271Signer },
               [{ schema: schema2Id, requests: [{ uid: uids[1] }, { uid }] }],
               { signatureType, from: sender },
               'Irrevocable'
@@ -1483,6 +1597,92 @@ describe('EAS', () => {
             ],
             signatures: [],
             revoker: await sender.getAddress(),
+            deadline: NO_EXPIRATION
+          }
+        ])
+      ).to.be.revertedWithCustomError(eas, 'InvalidLength');
+    });
+
+    it('should revert when multi ERC1271 delegation revoking with inconsistent input lengths', async () => {
+      const uid = await getUIDFromAttestTx(
+        eas.connect(sender).attest({
+          schema: schemaId,
+          data: {
+            recipient: await recipient.getAddress(),
+            expirationTime,
+            revocable: true,
+            refUID: ZERO_BYTES32,
+            data,
+            value: 0
+          }
+        })
+      );
+      const uid2 = await getUIDFromAttestTx(
+        eas.connect(sender).attest({
+          schema: schemaId,
+          data: {
+            recipient: await recipient.getAddress(),
+            expirationTime,
+            revocable: true,
+            refUID: ZERO_BYTES32,
+            data,
+            value: 0
+          }
+        })
+      );
+
+      const erc1271Address = await erc1271Signer.getAddress();
+      const dummySignature = '0x' + '1'.repeat(130); // 65 bytes signature
+
+      await expect(
+        eas.multiRevokeByERC1271Delegation([
+          {
+            schema: schemaId,
+            data: [
+              { uid, value: 0 },
+              { uid: uid2, value: 0 }
+            ],
+            signatures: [dummySignature],
+            revoker: erc1271Address,
+            deadline: NO_EXPIRATION
+          }
+        ])
+      ).to.be.revertedWithCustomError(eas, 'InvalidLength');
+
+      await expect(
+        eas.multiRevokeByERC1271Delegation([
+          {
+            schema: schemaId,
+            data: [],
+            signatures: [dummySignature],
+            revoker: erc1271Address,
+            deadline: NO_EXPIRATION
+          }
+        ])
+      ).to.be.revertedWithCustomError(eas, 'InvalidLength');
+
+      await expect(
+        eas.multiRevokeByERC1271Delegation([
+          {
+            schema: schemaId,
+            data: [{ uid, value: 0 }],
+            signatures: [dummySignature, dummySignature],
+            revoker: erc1271Address,
+            deadline: NO_EXPIRATION
+          }
+        ])
+      ).to.be.revertedWithCustomError(eas, 'InvalidLength');
+
+      await expect(
+        eas.multiRevokeByERC1271Delegation([
+          {
+            schema: schemaId,
+            data: [
+              { uid, value: 0 },
+              { uid: uid2, value: 0 }
+            ],
+            signatures: [],
+            revoker: erc1271Address,
             deadline: NO_EXPIRATION
           }
         ])

--- a/test/eip1271/EIP1271Verifier.ts
+++ b/test/eip1271/EIP1271Verifier.ts
@@ -299,6 +299,222 @@ describe('EIP1271Verifier', () => {
         });
       });
 
+      describe('verify ERC1271 attest', () => {
+        interface AttestationRequestData {
+          recipient: string;
+          expirationTime: bigint;
+          revocable: boolean;
+          refUID: string;
+          data: string;
+          value: bigint;
+        }
+
+        const schema = ZERO_BYTES32;
+        const deadline = NO_EXPIRATION;
+        let attestationRequest: AttestationRequestData;
+        let erc1271Signer: TestEIP1271Signer;
+
+        beforeEach(async () => {
+          attestationRequest = {
+            recipient: await recipient.getAddress(),
+            expirationTime: NO_EXPIRATION,
+            revocable: true,
+            refUID: ZERO_BYTES32,
+            data: ZERO_BYTES,
+            value: 1000n
+          };
+
+          erc1271Signer = await Contracts.TestEIP1271Signer.deploy();
+        });
+
+        const signERC1271DelegatedAttestation = async (
+          signer: TestEIP1271Signer,
+          attestationRequest: AttestationRequestData
+        ) => {
+          const nonce = await verifier.getNonce(await signer.getAddress());
+          const hash = await eip712Utils.hashDelegatedAttestation(
+            await signer.getAddress(),
+            schema,
+            attestationRequest.recipient,
+            attestationRequest.expirationTime,
+            attestationRequest.revocable,
+            attestationRequest.refUID,
+            attestationRequest.data,
+            attestationRequest.value,
+            nonce,
+            deadline
+          );
+
+          // Create a dummy signature and mock it in the contract
+          const dummySignature = solidityPacked(
+            ['bytes32', 'bytes32', 'uint8'],
+            [hash, keccak256(`${hash}${await latest()}`), 27]
+          );
+          await signer.mockSignature(hash, dummySignature);
+
+          return dummySignature;
+        };
+
+        it('should verify ERC1271 delegated attestation request', async () => {
+          for (let i = 0; i < 3; ++i) {
+            const signature = await signERC1271DelegatedAttestation(erc1271Signer, attestationRequest);
+
+            await expect(
+              verifier.verifyERC1271Attest({
+                schema,
+                data: attestationRequest,
+                signature,
+                attester: await erc1271Signer.getAddress(),
+                deadline
+              })
+            ).not.to.be.reverted;
+          }
+        });
+
+        it('should revert when verifying ERC1271 delegated attestation request with an expired deadline', async () => {
+          const signature = await signERC1271DelegatedAttestation(erc1271Signer, attestationRequest);
+
+          await expect(
+            verifier.verifyERC1271Attest({
+              schema,
+              data: attestationRequest,
+              signature,
+              attester: await erc1271Signer.getAddress(),
+              deadline: (await latest()) - duration.hours(1n)
+            })
+          ).to.be.revertedWithCustomError(verifier, 'DeadlineExpired');
+        });
+
+        it('should revert when verifying ERC1271 delegated attestation request with a wrong signature', async () => {
+          const signature = await signERC1271DelegatedAttestation(erc1271Signer, attestationRequest);
+
+          const wrongSignature = '0x' + '1'.repeat(130); // Invalid signature
+
+          await expect(
+            verifier.verifyERC1271Attest({
+              schema,
+              data: attestationRequest,
+              signature: wrongSignature,
+              attester: await erc1271Signer.getAddress(),
+              deadline
+            })
+          ).to.be.revertedWithCustomError(verifier, 'InvalidSignature');
+
+          const wrongSigner = await Contracts.TestEIP1271Signer.deploy();
+          await expect(
+            verifier.verifyERC1271Attest({
+              schema,
+              data: attestationRequest,
+              signature,
+              attester: await wrongSigner.getAddress(),
+              deadline
+            })
+          ).to.be.revertedWithCustomError(verifier, 'InvalidSignature');
+        });
+      });
+
+      describe('verify ERC1271 revoke', () => {
+        const schema = ZERO_BYTES32;
+        const deadline = NO_EXPIRATION;
+
+        interface RevocationRequestData {
+          uid: string;
+          value: bigint;
+        }
+
+        const revocationRequest: RevocationRequestData = {
+          uid: ZERO_BYTES32,
+          value: 1000n
+        };
+
+        let erc1271Signer: TestEIP1271Signer;
+
+        beforeEach(async () => {
+          erc1271Signer = await Contracts.TestEIP1271Signer.deploy();
+        });
+
+        const signERC1271DelegatedRevocation = async (
+          signer: TestEIP1271Signer,
+          revocationRequest: RevocationRequestData
+        ) => {
+          const nonce = await verifier.getNonce(await signer.getAddress());
+          const hash = await eip712Utils.hashDelegatedRevocation(
+            await signer.getAddress(),
+            schema,
+            revocationRequest.uid,
+            revocationRequest.value,
+            nonce,
+            deadline
+          );
+
+          // Create a dummy signature and mock it in the contract
+          const dummySignature = solidityPacked(
+            ['bytes32', 'bytes32', 'uint8'],
+            [hash, keccak256(`${hash}${await latest()}`), 27]
+          );
+          await signer.mockSignature(hash, dummySignature);
+
+          return dummySignature;
+        };
+
+        it('should verify ERC1271 delegated revocation request', async () => {
+          for (let i = 0; i < 3; ++i) {
+            const signature = await signERC1271DelegatedRevocation(erc1271Signer, revocationRequest);
+
+            await expect(
+              verifier.verifyERC1271Revoke({
+                schema,
+                data: revocationRequest,
+                signature,
+                revoker: await erc1271Signer.getAddress(),
+                deadline
+              })
+            ).not.to.be.reverted;
+          }
+        });
+
+        it('should revert when verifying ERC1271 delegated revocation request with an expired deadline', async () => {
+          const signature = await signERC1271DelegatedRevocation(erc1271Signer, revocationRequest);
+
+          await expect(
+            verifier.verifyERC1271Revoke({
+              schema,
+              data: revocationRequest,
+              signature,
+              revoker: await erc1271Signer.getAddress(),
+              deadline: (await latest()) - duration.hours(1n)
+            })
+          ).to.be.revertedWithCustomError(verifier, 'DeadlineExpired');
+        });
+
+        it('should revert when verifying ERC1271 delegated revocation request with a wrong signature', async () => {
+          const signature = await signERC1271DelegatedRevocation(erc1271Signer, revocationRequest);
+
+          const wrongSignature = '0x' + '1'.repeat(130); // Invalid signature
+
+          await expect(
+            verifier.verifyERC1271Revoke({
+              schema,
+              data: revocationRequest,
+              signature: wrongSignature,
+              revoker: await erc1271Signer.getAddress(),
+              deadline
+            })
+          ).to.be.revertedWithCustomError(verifier, 'InvalidSignature');
+
+          const wrongSigner = await Contracts.TestEIP1271Signer.deploy();
+          await expect(
+            verifier.verifyERC1271Revoke({
+              schema,
+              data: revocationRequest,
+              signature,
+              revoker: await wrongSigner.getAddress(),
+              deadline
+            })
+          ).to.be.revertedWithCustomError(verifier, 'InvalidSignature');
+        });
+      });
+
       describe('increasing nonces', () => {
         let user: Signer;
 

--- a/test/helpers/EAS.ts
+++ b/test/helpers/EAS.ts
@@ -1,5 +1,15 @@
 import { expect } from 'chai';
-import { BaseContract, hexlify, Signer, TransactionResponse } from 'ethers';
+import {
+  AbiCoder,
+  BaseContract,
+  hexlify,
+  keccak256,
+  Signer,
+  solidityPacked,
+  toUtf8Bytes,
+  TransactionResponse
+} from 'ethers';
+import Contracts, { TestEIP1271Signer } from '../../components/Contracts';
 import { SchemaRegistry, SchemaResolver, TestEAS } from '../../typechain-types';
 import {
   MultiDelegatedProxyAttestationRequestStruct,
@@ -8,7 +18,9 @@ import {
 import {
   AttestationStructOutput,
   MultiDelegatedAttestationRequestStruct,
-  MultiDelegatedRevocationRequestStruct
+  MultiDelegatedRevocationRequestStruct,
+  MultiERC1271DelegatedAttestationRequestStruct,
+  MultiERC1271DelegatedRevocationRequestStruct
 } from '../../typechain-types/contracts/IEAS';
 import { NO_EXPIRATION, ZERO_BYTES32 } from '../../utils/Constants';
 import {
@@ -44,13 +56,15 @@ export const registerSchema = async (
 export enum SignatureType {
   Direct = 'direct',
   Delegated = 'delegated',
-  DelegatedProxy = 'delegated-proxy'
+  DelegatedProxy = 'delegated-proxy',
+  ERC1271Delegated = 'erc1271-delegated'
 }
 
 export interface RequestContracts {
   eas: TestEAS;
   eip712Utils?: EIP712Utils;
   eip712ProxyUtils?: EIP712ProxyUtils;
+  erc1271Signer?: TestEIP1271Signer;
 }
 
 export interface AttestationOptions {
@@ -115,6 +129,7 @@ export const expectAttestation = async (
 
   const msgValue = options.value ?? value;
   let uid;
+  let erc1271AttesterAddress: string | undefined;
 
   let res: TransactionResponse;
 
@@ -226,6 +241,63 @@ export const expectAttestation = async (
 
       break;
     }
+
+    case SignatureType.ERC1271Delegated: {
+      if (!eip712Utils) {
+        throw new Error('Invalid verifier');
+      }
+
+      // For ERC1271, we need to use a contract signer
+      let erc1271Signer = contracts.erc1271Signer;
+      if (!erc1271Signer) {
+        erc1271Signer = await Contracts.TestEIP1271Signer.deploy();
+      }
+      const erc1271Address = await erc1271Signer.getAddress();
+      erc1271AttesterAddress = erc1271Address;
+
+      const nonce = await eas.getNonce(erc1271Address);
+      const hash = await eip712Utils.hashDelegatedAttestation(
+        erc1271Address,
+        schema,
+        recipient,
+        expirationTime,
+        revocable,
+        refUID,
+        data,
+        msgValue,
+        nonce,
+        deadline
+      );
+
+      // Create a dummy signature and mock it in the contract
+      // For ERC1271, we just need any valid bytes signature - we'll use the hash with some padding
+      const dummySignature = solidityPacked(
+        ['bytes32', 'bytes32', 'uint8'],
+        [hash, keccak256(AbiCoder.defaultAbiCoder().encode(['bytes32', 'uint256'], [hash, nonce])), 27]
+      );
+      await erc1271Signer.mockSignature(hash, dummySignature);
+
+      const args = [
+        {
+          schema,
+          data: { recipient, expirationTime, revocable, refUID, data, value },
+          signature: dummySignature,
+          attester: erc1271Address,
+          deadline
+        },
+        {
+          value: msgValue
+        }
+      ] as const;
+
+      const returnedUID = await eas.connect(txSender).attestByERC1271Delegation.staticCall(...args);
+      res = await eas.connect(txSender).attestByERC1271Delegation(...args);
+
+      uid = await getUIDFromAttestTx(res);
+      expect(uid).to.equal(returnedUID);
+
+      break;
+    }
   }
 
   if (!options.skipBalanceCheck) {
@@ -234,10 +306,18 @@ export const expectAttestation = async (
     expect(await getBalance(await txSender.getAddress())).to.equal(prevBalance - value - transactionCost);
   }
 
-  const attester =
-    signatureType !== SignatureType.DelegatedProxy
-      ? await txSender.getAddress()
-      : await eip712ProxyUtils?.proxy.getAddress();
+  let attester: string;
+  if (signatureType === SignatureType.DelegatedProxy) {
+    attester = await eip712ProxyUtils!.proxy.getAddress();
+  } else if (signatureType === SignatureType.ERC1271Delegated) {
+    // Use the erc1271AttesterAddress that was set in the switch case above
+    if (!erc1271AttesterAddress) {
+      throw new Error('ERC1271 attester address not set');
+    }
+    attester = erc1271AttesterAddress;
+  } else {
+    attester = await txSender.getAddress();
+  }
 
   await expect(res).to.emit(eas, 'Attested').withArgs(recipient, attester, uid, schema);
 
@@ -420,6 +500,7 @@ export const expectMultiAttestations = async (
 
   let uids: string[] = [];
   let res: TransactionResponse;
+  let erc1271AttesterAddress: string | undefined;
 
   switch (signatureType) {
     case SignatureType.Direct: {
@@ -546,6 +627,73 @@ export const expectMultiAttestations = async (
 
       break;
     }
+
+    case SignatureType.ERC1271Delegated: {
+      if (!eip712Utils) {
+        throw new Error('Invalid verifier');
+      }
+
+      // For ERC1271, we need to use a contract signer
+      let erc1271Signer = contracts.erc1271Signer;
+      if (!erc1271Signer) {
+        erc1271Signer = await Contracts.TestEIP1271Signer.deploy();
+      }
+      const erc1271Address = await erc1271Signer.getAddress();
+      erc1271AttesterAddress = erc1271Address;
+
+      const multiERC1271DelegatedAttestationRequests: MultiERC1271DelegatedAttestationRequestStruct[] = [];
+
+      let nonce = await eas.getNonce(erc1271Address);
+
+      for (const { schema, data } of multiAttestationRequests) {
+        const signatures: string[] = [];
+
+        for (const request of data) {
+          const hash = await eip712Utils.hashDelegatedAttestation(
+            erc1271Address,
+            schema,
+            request.recipient,
+            request.expirationTime,
+            request.revocable,
+            request.refUID,
+            request.data,
+            msgValue,
+            nonce,
+            deadline
+          );
+
+          // Create a dummy signature and mock it in the contract
+          // For ERC1271, we just need any valid bytes signature - we'll use the hash with some padding
+          const dummySignature = solidityPacked(
+            ['bytes32', 'bytes32', 'uint8'],
+            [hash, keccak256(AbiCoder.defaultAbiCoder().encode(['bytes32', 'uint256'], [hash, nonce])), 27]
+          );
+          await erc1271Signer.mockSignature(hash, dummySignature);
+
+          signatures.push(dummySignature);
+
+          nonce++;
+        }
+
+        multiERC1271DelegatedAttestationRequests.push({
+          schema,
+          data,
+          signatures,
+          attester: erc1271Address,
+          deadline
+        });
+      }
+
+      const args = [multiERC1271DelegatedAttestationRequests, { value: msgValue }] as const;
+
+      const returnedUIDs = await eas.connect(txSender).multiAttestByERC1271Delegation.staticCall(...args);
+      res = await eas.connect(txSender).multiAttestByERC1271Delegation(...args);
+
+      uids = await getUIDsFromMultiAttestTx(res);
+      expect(uids).to.deep.equal(returnedUIDs);
+
+      break;
+    }
   }
 
   if (!options.skipBalanceCheck) {
@@ -559,10 +707,18 @@ export const expectMultiAttestations = async (
     for (const request of data) {
       const uid = uids[i++];
 
-      const attester =
-        signatureType !== SignatureType.DelegatedProxy
-          ? await txSender.getAddress()
-          : await eip712ProxyUtils?.proxy.getAddress();
+      let attester: string;
+      if (signatureType === SignatureType.DelegatedProxy) {
+        attester = await eip712ProxyUtils!.proxy.getAddress();
+      } else if (signatureType === SignatureType.ERC1271Delegated) {
+        // Use the erc1271AttesterAddress that was set in the switch case above
+        if (!erc1271AttesterAddress) {
+          throw new Error('ERC1271 attester address not set');
+        }
+        attester = erc1271AttesterAddress;
+      } else {
+        attester = await txSender.getAddress();
+      }
 
       await expect(res).to.emit(eas, 'Attested').withArgs(request.recipient, attester, uid, schema);
 
@@ -744,6 +900,7 @@ export const expectRevocation = async (
   const attestation = await eas.getAttestation(uid);
 
   let res;
+  let erc1271RevokerAddress: string | undefined;
 
   switch (signatureType) {
     case SignatureType.Direct: {
@@ -813,6 +970,44 @@ export const expectRevocation = async (
 
       break;
     }
+
+    case SignatureType.ERC1271Delegated: {
+      if (!eip712Utils) {
+        throw new Error('Invalid verifier');
+      }
+
+      // For ERC1271, we need to use a contract signer
+      let erc1271Signer = contracts.erc1271Signer;
+      if (!erc1271Signer) {
+        erc1271Signer = await Contracts.TestEIP1271Signer.deploy();
+      }
+      const erc1271Address = await erc1271Signer.getAddress();
+      erc1271RevokerAddress = erc1271Address;
+
+      const nonce = await eas.getNonce(erc1271Address);
+      const hash = await eip712Utils.hashDelegatedRevocation(erc1271Address, schema, uid, msgValue, nonce, deadline);
+
+      // Create a dummy signature and mock it in the contract
+      // For ERC1271, we just need any valid bytes signature - we'll use the hash with some padding
+      const dummySignature = solidityPacked(
+        ['bytes32', 'bytes32', 'uint8'],
+        [hash, keccak256(AbiCoder.defaultAbiCoder().encode(['bytes32', 'uint256'], [hash, nonce])), 27]
+      );
+      await erc1271Signer.mockSignature(hash, dummySignature);
+
+      res = await eas.connect(txSender).revokeByERC1271Delegation(
+        {
+          schema,
+          data: { uid, value },
+          signature: dummySignature,
+          revoker: erc1271Address,
+          deadline
+        },
+        { value: msgValue }
+      );
+
+      break;
+    }
   }
 
   if (!options.skipBalanceCheck) {
@@ -821,10 +1016,18 @@ export const expectRevocation = async (
     expect(await getBalance(await txSender.getAddress())).to.equal(prevBalance - value - transactionCost);
   }
 
-  const attester =
-    signatureType !== SignatureType.DelegatedProxy
-      ? await txSender.getAddress()
-      : await eip712ProxyUtils?.proxy.getAddress();
+  let attester: string;
+  if (signatureType === SignatureType.DelegatedProxy) {
+    attester = await eip712ProxyUtils!.proxy.getAddress();
+  } else if (signatureType === SignatureType.ERC1271Delegated) {
+    // Use the erc1271RevokerAddress that was set in the switch case above
+    if (!erc1271RevokerAddress) {
+      throw new Error('ERC1271 revoker address not set');
+    }
+    attester = erc1271RevokerAddress;
+  } else {
+    attester = await txSender.getAddress();
+  }
   await expect(res).to.emit(eas, 'Revoked').withArgs(attestation.recipient, attester, uid, attestation.schema);
 
   const attestation2 = await eas.getAttestation(uid);
@@ -866,6 +1069,7 @@ export const expectMultiRevocations = async (
   const msgValue = options.value ?? requestedValue;
 
   let res: TransactionResponse;
+  let erc1271RevokerAddress: string | undefined;
 
   switch (signatureType) {
     case SignatureType.Direct: {
@@ -960,6 +1164,65 @@ export const expectMultiRevocations = async (
 
       break;
     }
+
+    case SignatureType.ERC1271Delegated: {
+      if (!eip712Utils) {
+        throw new Error('Invalid verifier');
+      }
+
+      // For ERC1271, we need to use a contract signer
+      let erc1271Signer = contracts.erc1271Signer;
+      if (!erc1271Signer) {
+        erc1271Signer = await Contracts.TestEIP1271Signer.deploy();
+      }
+      const erc1271Address = await erc1271Signer.getAddress();
+      erc1271RevokerAddress = erc1271Address;
+
+      const multiERC1271DelegatedRevocationRequests: MultiERC1271DelegatedRevocationRequestStruct[] = [];
+
+      let nonce = await eas.getNonce(erc1271Address);
+
+      for (const { schema, data } of multiRevocationRequests) {
+        const signatures: string[] = [];
+
+        for (const request of data) {
+          const hash = await eip712Utils.hashDelegatedRevocation(
+            erc1271Address,
+            schema,
+            request.uid,
+            msgValue,
+            nonce,
+            deadline
+          );
+
+          // Create a dummy signature and mock it in the contract
+          // For ERC1271, we just need any valid bytes signature - we'll use the hash with some padding
+          const dummySignature = solidityPacked(
+            ['bytes32', 'bytes32', 'uint8'],
+            [hash, keccak256(AbiCoder.defaultAbiCoder().encode(['bytes32', 'uint256'], [hash, nonce])), 27]
+          );
+          await erc1271Signer.mockSignature(hash, dummySignature);
+
+          signatures.push(dummySignature);
+
+          nonce++;
+        }
+
+        multiERC1271DelegatedRevocationRequests.push({
+          schema,
+          data,
+          signatures,
+          revoker: erc1271Address,
+          deadline
+        });
+      }
+
+      res = await eas.connect(txSender).multiRevokeByERC1271Delegation(multiERC1271DelegatedRevocationRequests, {
+        value: msgValue
+      });
+
+      break;
+    }
   }
 
   if (!options.skipBalanceCheck) {
@@ -968,10 +1231,18 @@ export const expectMultiRevocations = async (
     expect(await getBalance(await txSender.getAddress())).to.equal(prevBalance - requestedValue - transactionCost);
   }
 
-  const attester =
-    signatureType !== SignatureType.DelegatedProxy
-      ? await txSender.getAddress()
-      : await eip712ProxyUtils?.proxy.getAddress();
+  let attester: string;
+  if (signatureType === SignatureType.DelegatedProxy) {
+    attester = await eip712ProxyUtils!.proxy.getAddress();
+  } else if (signatureType === SignatureType.ERC1271Delegated) {
+    // Use the erc1271RevokerAddress that was set in the switch case above
+    if (!erc1271RevokerAddress) {
+      throw new Error('ERC1271 revoker address not set');
+    }
+    attester = erc1271RevokerAddress;
+  } else {
+    attester = await txSender.getAddress();
+  }
 
   for (const data of requests) {
     for (const request of data.requests) {


### PR DESCRIPTION
**Purpose:**
Enables smart contract wallets to sign attestations and revocations using ERC1271, allowing contract-based accounts to use EAS without private key management.

**Changes:**
`IEAS.sol `
- Structs:
  - `ERC1271DelegatedAttestationRequest` — single ERC1271 attestation request
  - `MultiERC1271DelegatedAttestationRequest` — batch ERC1271 attestation requests
  - `ERC1271DelegatedRevocationRequest` — single ERC1271 revocation request
  - `MultiERC1271DelegatedRevocationRequest` — batch ERC1271 revocation requests

- Interface functions:
  - `attestByERC1271Delegation()` — single attestation via ERC1271
  - `multiAttestByERC1271Delegation()` — batch attestations via ERC1271
  - `revokeByERC1271Delegation()` — single revocation via ERC1271
  - `multiRevokeByERC1271Delegation()` — batch revocations via ERC1271

`EAS.sol`
- Implemented the four ERC1271 delegation functions from the interface
- Mirrors existing delegated functions but uses ERC1271 signature verification
- Supports contract-based signers (smart contract wallets) in addition to EOA signatures

`EIP1271Verifier.sol`
- `_verifyERC1271Attest()` — verifies ERC1271 signatures for attestations
- `_verifyERC1271Revoke()` — verifies ERC1271 signatures for revocations

**Tests:**
38 new tests have been added to cover new changes and preserve the coverage:


File                              |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------------------------|----------|----------|----------|----------|----------------|
 contracts/                       |      100 |      100 |      100 |      100 |                |
  Common.sol                      |      100 |      100 |      100 |      100 |                |
  EAS.sol                         |      100 |      100 |      100 |      100 |                |
  IEAS.sol                        |      100 |      100 |      100 |      100 |                |
  ISchemaRegistry.sol             |      100 |      100 |      100 |      100 |                |
  ISemver.sol                     |      100 |      100 |      100 |      100 |                |
  Indexer.sol                     |      100 |      100 |      100 |      100 |                |
  SchemaRegistry.sol              |      100 |      100 |      100 |      100 |                |
  Semver.sol                      |      100 |      100 |      100 |      100 |                |
 contracts/eip1271/               |      100 |      100 |      100 |      100 |                |
  EIP1271Verifier.sol             |      100 |      100 |      100 |      100 |                |
 contracts/eip712/proxy/          |      100 |      100 |      100 |      100 |                |
  EIP712Proxy.sol                 |      100 |      100 |      100 |      100 |                |
 contracts/eip712/proxy/examples/ |      100 |      100 |      100 |      100 |                |
  PermissionedEIP712Proxy.sol     |      100 |      100 |      100 |      100 |                |
 contracts/resolver/              |      100 |      100 |      100 |      100 |                |
  ISchemaResolver.sol             |      100 |      100 |      100 |      100 |                |
  SchemaResolver.sol              |      100 |      100 |      100 |      100 |                |
 contracts/resolver/examples/     |      100 |      100 |      100 |      100 |                |
  AttestationResolver.sol         |      100 |      100 |      100 |      100 |                |
  AttesterResolver.sol            |      100 |      100 |      100 |      100 |                |
  DataResolver.sol                |      100 |      100 |      100 |      100 |                |
  ExpirationTimeResolver.sol      |      100 |      100 |      100 |      100 |                |
  PayingResolver.sol              |      100 |      100 |      100 |      100 |                |
  RecipientResolver.sol           |      100 |      100 |      100 |      100 |                |
  RevocationResolver.sol          |      100 |      100 |      100 |      100 |                |
  TokenResolver.sol               |      100 |      100 |      100 |      100 |                |
  ValueResolver.sol               |      100 |      100 |      100 |      100 |                |
All files                         |      100 |      100 |      100 |      100 |                |
